### PR TITLE
[docs] Include example of `gin.parse_config_file`

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,12 @@ parameters:
 DNN.layer_sizes = (1024, 512, 128)
 ```
 
+Finally, after defining or importing all configurable classes or functions, parse your config file to bind your configurations:
+
+```python
+gin.parse_config_file('config.gin')
+```
+
 Note that no other changes are required to the Python code, beyond adding the
 `gin.configurable` decorator and a call to one of Gin's parsing functions.
 


### PR DESCRIPTION
As a first-time user of gin, it seemed like gin might automatically detect and parse my `config.gin` file.  But it appears that we're actually required to call `gin.parse_config_file`, so I think it would help to explicitly include an example of that in the documentation of basic usage.