### PR TITLE
Add module for sklearn external configurables

### DIFF
--- a/gin/sklearn/__init__.py
+++ b/gin/sklearn/__init__.py
@@ -1,0 +1,68 @@
+# coding=utf-8
+# Copyright 2018 The Gin-Config Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Init file for scikit-learn-specific Gin-Config package."""
+
+# pylint: disable=g-import-not-at-top
+
+
+# Ensure scikit-learn is importable and its version is sufficiently recent.
+# This needs to happen before anything else, since the imports below will try
+# to import scikit-learn, too.
+def _ensure_sklearn_install():  # pylint: disable=g-statement-before-imports
+  """Attempt to import scikit-learn, and ensure its version is sufficient.
+
+  Raises:
+    ImportError: If either scikit-learn is not importable or its version is
+      inadequate.
+  """
+  try:
+    import sklearn
+  except ImportError:
+    # Print more informative error message, then reraise.
+    print("\n\nFailed to import scikit-learn. Please note that scikit-learn "
+          "is not installed by default when you install Gin-Config. This is "
+          "so that users can decide whether to install TensorFlow, "
+          "GPU-enabled Tensorflow, PyTorch, or scikit-learn. To use "
+          "Gin-Config with scikit-learn, please install the most recent "
+          "version of scikit-learn, by following instructions at "
+          "https://scikit-learn.org/stable/install.html.\n\n")
+    raise
+
+  # Update this whenever we need to depend on a newer scikit-learn release.
+  required_sklearn_version = "0.19.1"
+
+  import distutils.version
+
+  if (distutils.version.LooseVersion(sklearn.__version__) <
+      distutils.version.LooseVersion(required_sklearn_version)):
+    raise ImportError(
+        "This version of Gin-Config requires TensorFlow "
+        "version >= {required}; Detected an installation of version {present}. "
+        "Please upgrade scikit-learn to proceed.".format(
+            required=required_sklearn_version,
+            present=sklearn.__version__))
+
+
+_ensure_sklearn_install()
+
+
+# Cleanup symbols to avoid polluting namespace.
+import sys as _sys
+import .external_configurables as _ext
+for symbol in ["_ensure_sklearn_install", "_sys", "_ext"]:
+  delattr(_sys.modules[__name__], symbol)
+
+# pylint: enable=g-import-not-at-top

--- a/gin/sklearn/external_configurables.py
+++ b/gin/sklearn/external_configurables.py
@@ -1,0 +1,276 @@
+# coding=utf-8
+# Copyright 2018 The Gin-Config Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Supplies a default set of configurables from core scikit-learn."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+from gin import config
+
+import sklearn
+
+
+# Most of the classes mentioned in the docs:
+# https://scikit-learn.org/stable/modules/classes.html
+
+# Clustering
+gin.external_configurable(sklearn.cluster.AffinityPropagation)
+gin.external_configurable(sklearn.cluster.AgglomerativeClustering)
+gin.external_configurable(sklearn.cluster.Birch)
+gin.external_configurable(sklearn.cluster.DBSCAN)
+gin.external_configurable(sklearn.cluster.FeatureAgglomeration)
+gin.external_configurable(sklearn.cluster.KMeans)
+gin.external_configurable(sklearn.cluster.MiniBatchKMeans)
+gin.external_configurable(sklearn.cluster.MeanShift)
+gin.external_configurable(sklearn.cluster.OPTICS)
+gin.external_configurable(sklearn.cluster.SpectralClustering)
+gin.external_configurable(sklearn.cluster.SpectralBiclustering)
+gin.external_configurable(sklearn.cluster.SpectralCoclustering)
+
+# Cross Decomposition
+gin.external_configurable(sklearn.cross_decomposition.CCA)
+gin.external_configurable(sklearn.cross_decomposition.PLSCanonical)
+gin.external_configurable(sklearn.cross_decomposition.PLSRegression)
+gin.external_configurable(sklearn.cross_decomposition.PLSSVD)
+
+# Decomposition
+gin.external_configurable(sklearn.decomposition.DictionaryLearning)
+gin.external_configurable(sklearn.decomposition.FactorAnalysis)
+gin.external_configurable(sklearn.decomposition.FastICA)
+gin.external_configurable(sklearn.decomposition.IncrementalPCA)
+gin.external_configurable(sklearn.decomposition.KernelPCA)
+gin.external_configurable(sklearn.decomposition.LatentDirichletAllocation)
+gin.external_configurable(sklearn.decomposition.MiniBatchDictionaryLearning)
+gin.external_configurable(sklearn.decomposition.MiniBatchSparsePCA)
+gin.external_configurable(sklearn.decomposition.NMF)
+gin.external_configurable(sklearn.decomposition.PCA)
+gin.external_configurable(sklearn.decomposition.SparsePCA)
+gin.external_configurable(sklearn.decomposition.SparseCoder)
+gin.external_configurable(sklearn.decomposition.TruncatedSVD)
+
+# Discriminant Analysis
+gin.external_configurable(sklearn.discriminant_analysis.LinearDiscriminantAnalysis)
+gin.external_configurable(sklearn.discriminant_analysis.QuadraticDiscriminantAnalysis)
+
+# Ensemble
+gin.external_configurable(sklearn.ensemble.AdaBoostClassifier)
+gin.external_configurable(sklearn.ensemble.AdaBoostRegressor)
+gin.external_configurable(sklearn.ensemble.BaggingClassifier)
+gin.external_configurable(sklearn.ensemble.BaggingRegressor)
+gin.external_configurable(sklearn.ensemble.ExtraTreesClassifier)
+gin.external_configurable(sklearn.ensemble.ExtraTreesRegressor)
+gin.external_configurable(sklearn.ensemble.GradientBoostingClassifier)
+gin.external_configurable(sklearn.ensemble.GradientBoostingRegressor)
+gin.external_configurable(sklearn.ensemble.IsolationForest)
+gin.external_configurable(sklearn.ensemble.RandomForestClassifier)
+gin.external_configurable(sklearn.ensemble.RandomForestRegressor)
+gin.external_configurable(sklearn.ensemble.StackingClassifier)
+gin.external_configurable(sklearn.ensemble.StackingRegressor)
+gin.external_configurable(sklearn.ensemble.VotingClassifier)
+gin.external_configurable(sklearn.ensemble.VotingRegressor)
+
+# Feature Extraction
+gin.external_configurable(sklearn.feature_extraction.DictVectorizer)
+gin.external_configurable(sklearn.feature_extraction.FeatureHasher)
+gin.external_configurable(sklearn.feature_extraction.image.extract_patches_2d)
+gin.external_configurable(sklearn.feature_extraction.image.grid_to_graph)
+gin.external_configurable(sklearn.feature_extraction.image.img_to_graph)
+gin.external_configurable(sklearn.feature_extraction.image.reconstruct_from_patches_2d)
+gin.external_configurable(sklearn.feature_extraction.image.PatchExtractor)
+gin.external_configurable(sklearn.feature_extraction.text.CountVectorizer)
+gin.external_configurable(sklearn.feature_extraction.text.HashingVectorizer)
+gin.external_configurable(sklearn.feature_extraction.text.TfidfTransformer)
+gin.external_configurable(sklearn.feature_extraction.text.TfidfVectorizer)
+
+# Feature Selection
+gin.external_configurable(sklearn.feature_selection.GenericUnivariateSelect)
+gin.external_configurable(sklearn.feature_selection.SelectPercentile)
+gin.external_configurable(sklearn.feature_selection.SelectKBest)
+gin.external_configurable(sklearn.feature_selection.SelectFpr)
+gin.external_configurable(sklearn.feature_selection.SelectFdr)
+gin.external_configurable(sklearn.feature_selection.SelectFromModel)
+gin.external_configurable(sklearn.feature_selection.SelectFwe)
+gin.external_configurable(sklearn.feature_selection.RFE)
+gin.external_configurable(sklearn.feature_selection.RFECV)
+gin.external_configurable(sklearn.feature_selection.VarianceThreshold)
+gin.external_configurable(sklearn.feature_selection.chi2)
+gin.external_configurable(sklearn.feature_selection.f_classif)
+gin.external_configurable(sklearn.feature_selection.f_regression)
+gin.external_configurable(sklearn.feature_selection.mutual_info_classif)
+gin.external_configurable(sklearn.feature_selection.mutual_info_regression)
+
+# Gaussian Processes
+gin.external_configurable(sklearn.gaussian_process.GaussianProcessRegressor)
+gin.external_configurable(sklearn.gaussian_process.GaussianProcessClassifier)
+gin.external_configurable(sklearn.gaussian_process.kernels.CompoundKernel)
+gin.external_configurable(sklearn.gaussian_process.kernels.ConstantKernel)
+gin.external_configurable(sklearn.gaussian_process.kernels.DotProduct)
+gin.external_configurable(sklearn.gaussian_process.kernels.ExpSineSquared)
+gin.external_configurable(sklearn.gaussian_process.kernels.Exponentiation)
+gin.external_configurable(sklearn.gaussian_process.kernels.Hyperparameter)
+gin.external_configurable(sklearn.gaussian_process.kernels.Matern)
+gin.external_configurable(sklearn.gaussian_process.kernels.PairwiseKernel)
+gin.external_configurable(sklearn.gaussian_process.kernels.Product)
+gin.external_configurable(sklearn.gaussian_process.kernels.RBF)
+gin.external_configurable(sklearn.gaussian_process.kernels.RationalQuadratic)
+gin.external_configurable(sklearn.gaussian_process.kernels.Sum)
+gin.external_configurable(sklearn.gaussian_process.kernels.WhiteKernel)
+
+# Impute
+gin.external_configurable(sklearn.impute.SimpleImputer)
+gin.external_configurable(sklearn.impute.MissingIndicator)
+gin.external_configurable(sklearn.impute.KNNImputer)
+
+# Isotonic
+gin.external_configurable(sklearn.isotonic.IsotonicRegression)
+
+# Kernel Approximation
+gin.external_configurable(sklearn.kernel_approximation.AdditiveChi2Sampler)
+gin.external_configurable(sklearn.kernel_approximation.Nystroem)
+gin.external_configurable(sklearn.kernel_approximation.RBFSampler)
+gin.external_configurable(sklearn.kernel_approximation.SkewedChi2Sampler)
+
+# Kernel Ridge Regression
+gin.external_configurable(sklearn.kernel_ridge.KernelRidge)
+
+# Linear Classifiers
+gin.external_configurable(sklearn.linear_model.LogisticRegression)
+gin.external_configurable(sklearn.linear_model.LogisticRegressionCV)
+gin.external_configurable(sklearn.linear_model.PassiveAggressiveClassifier)
+gin.external_configurable(sklearn.linear_model.Perceptron)
+gin.external_configurable(sklearn.linear_model.RidgeClassifier)
+gin.external_configurable(sklearn.linear_model.RidgeClassifierCV)
+gin.external_configurable(sklearn.linear_model.SGDClassifier)
+
+# Classical Linear Regressors
+gin.external_configurable(sklearn.linear_model.LinearRegression)
+gin.external_configurable(sklearn.linear_model.Ridge)
+gin.external_configurable(sklearn.linear_model.RidgeCV)
+gin.external_configurable(sklearn.linear_model.SGDRegressor)
+
+# Regressors with variable selection
+gin.external_configurable(sklearn.linear_model.ElasticNet)
+gin.external_configurable(sklearn.linear_model.ElasticNetCV)
+gin.external_configurable(sklearn.linear_model.Lars)
+gin.external_configurable(sklearn.linear_model.LarsCV)
+gin.external_configurable(sklearn.linear_model.Lasso)
+gin.external_configurable(sklearn.linear_model.LassoCV)
+gin.external_configurable(sklearn.linear_model.LassoLars)
+gin.external_configurable(sklearn.linear_model.LassoLarsCV)
+gin.external_configurable(sklearn.linear_model.OrthogonalMatchingPursuit)
+gin.external_configurable(sklearn.linear_model.OrthogonalMatchingPursuitCV)
+
+# Bayesian Regressors
+gin.external_configurable(sklearn.linear_model.ARDRegression)
+gin.external_configurable(sklearn.linear_model.BayesianRidge)
+
+# Multi-task Linear Regressors with Variable Selection
+gin.external_configurable(sklearn.linear_model.MultiTaskElasticNet)
+gin.external_configurable(sklearn.linear_model.MultiTaskElasticNetCV)
+gin.external_configurable(sklearn.linear_model.MultiTaskLasso)
+gin.external_configurable(sklearn.linear_model.MultiTaskLassoCV)
+
+# Outlier-robust Regressors
+gin.external_configurable(sklearn.linear_model.HuberRegressor)
+gin.external_configurable(sklearn.linear_model.RANSACRegressor)
+gin.external_configurable(sklearn.linear_model.TheilSenRegressor)
+
+# Miscellaneous
+gin.external_configurable(sklearn.linear_model.PassiveAggressiveRegressor)
+
+# Manifold
+gin.external_configurable(sklearn.manifold.Isomap)
+gin.external_configurable(sklearn.manifold.LocallyLinearEmbedding)
+gin.external_configurable(sklearn.manifold.MDS)
+gin.external_configurable(sklearn.manifold.SpectralEmbedding)
+gin.external_configurable(sklearn.manifold.TSNE)
+
+# Mixture Models
+gin.external_configurable(sklearn.mixture.GaussianMixture)
+gin.external_configurable(sklearn.mixture.BayesianGaussianMixture)
+
+# Multiclass
+gin.external_configurable(sklearn.multiclass.OneVsRestClassifier)
+gin.external_configurable(sklearn.multiclass.OneVsOneClassifier)
+gin.external_configurable(sklearn.multiclass.OutputCodeClassifier)
+
+# Multioutput
+gin.external_configurable(sklearn.multioutput.ClassifierChain)
+gin.external_configurable(sklearn.multioutput.MultiOutputRegressor)
+gin.external_configurable(sklearn.multioutput.MultiOutputClassifier)
+gin.external_configurable(sklearn.multioutput.RegressorChain)
+
+# Naive Bayes
+gin.external_configurable(sklearn.naive_bayes.BernoulliNB)
+gin.external_configurable(sklearn.naive_bayes.CategoricalNB)
+gin.external_configurable(sklearn.naive_bayes.ComplementNB)
+gin.external_configurable(sklearn.naive_bayes.GaussianNB)
+gin.external_configurable(sklearn.naive_bayes.MultinomialNB)
+
+# Nearest Neighbors
+gin.external_configurable(sklearn.neighbors.BallTree)
+gin.external_configurable(sklearn.neighbors.KDTree)
+gin.external_configurable(sklearn.neighbors.KNeighborsClassifier)
+gin.external_configurable(sklearn.neighbors.KNeighborsRegressor)
+gin.external_configurable(sklearn.neighbors.LocalOutlierFactor)
+gin.external_configurable(sklearn.neighbors.RadiusNeighborsClassifier)
+gin.external_configurable(sklearn.neighbors.RadiusNeighborsRegressor)
+gin.external_configurable(sklearn.neighbors.NearestCentroid)
+gin.external_configurable(sklearn.neighbors.NearestNeighbors)
+gin.external_configurable(sklearn.neighbors.NeighborhoodComponentsAnalysis)
+
+# Pipeline
+gin.external_configurable(sklearn.pipeline.FeatureUnion)
+gin.external_configurable(sklearn.pipeline.Pipeline)
+
+# Preprocessing
+gin.external_configurable(sklearn.preprocessing.Binarizer)
+gin.external_configurable(sklearn.preprocessing.FunctionTransformer)
+gin.external_configurable(sklearn.preprocessing.KBinsDiscretizer)
+gin.external_configurable(sklearn.preprocessing.KernelCenterer)
+gin.external_configurable(sklearn.preprocessing.LabelBinarizer)
+gin.external_configurable(sklearn.preprocessing.LabelEncoder)
+gin.external_configurable(sklearn.preprocessing.MultiLabelBinarizer)
+gin.external_configurable(sklearn.preprocessing.MaxAbsScaler)
+gin.external_configurable(sklearn.preprocessing.MinMaxScaler)
+gin.external_configurable(sklearn.preprocessing.Normalizer)
+gin.external_configurable(sklearn.preprocessing.OneHotEncoder)
+gin.external_configurable(sklearn.preprocessing.OrdinalEncoder)
+gin.external_configurable(sklearn.preprocessing.PolynomialFeatures)
+gin.external_configurable(sklearn.preprocessing.PowerTransformer)
+gin.external_configurable(sklearn.preprocessing.QuantileTransformer)
+gin.external_configurable(sklearn.preprocessing.RobustScaler)
+gin.external_configurable(sklearn.preprocessing.StandardScaler)
+
+# Random Projection
+gin.external_configurable(sklearn.random_projection.GaussianRandomProjection)
+gin.external_configurable(sklearn.random_projection.SparseRandomProjection)
+
+# Support Vector Machines
+gin.external_configurable(sklearn.svm.LinearSVC)
+gin.external_configurable(sklearn.svm.LinearSVR)
+gin.external_configurable(sklearn.svm.NuSVC)
+gin.external_configurable(sklearn.svm.NuSVR)
+gin.external_configurable(sklearn.svm.OneClassSVM)
+gin.external_configurable(sklearn.svm.SVC)
+gin.external_configurable(sklearn.svm.SVR)
+
+# Decision Trees
+gin.external_configurable(sklearn.tree.DecisionTreeClassifier)
+gin.external_configurable(sklearn.tree.DecisionTreeRegressor)
+gin.external_configurable(sklearn.tree.ExtraTreeClassifier)
+gin.external_configurable(sklearn.tree.ExtraTreeRegressor)


### PR DESCRIPTION
#### What is the subject of this PR?

As a continuation of #48, I prepared a module for configuring most of the `scikit-learn` estimators with `gin-config`.

#### Details

That's just plain marking most of `scikit-learn` stable public API as configurables.

#### Remarks

✅ I signed the CLA.