### PR TITLE
add parse_with option to parse_config()

### DIFF
--- a/gin/config.py
+++ b/gin/config.py
@@ -1532,7 +1532,7 @@ class ParsedConfigFileIncludesAndImports(
   pass
 
 
-def parse_config(bindings, skip_unknown=False):
+def parse_config(bindings, skip_unknown=False, with_scope=''):
   """Parse a file, string, or list of strings containing parameter bindings.
 
   Parses parameter binding strings to set up the global configuration.  Once
@@ -1623,6 +1623,8 @@ def parse_config(bindings, skip_unknown=False):
   for statement in parser:
     if isinstance(statement, config_parser.BindingStatement):
       scope, selector, arg_name, value, location = statement
+      if with_scope:
+          scope = '{}/{}'.format(with_scope, scope) if scope else with_scope
       if not arg_name:
         macro_name = '{}/{}'.format(scope, selector) if scope else selector
         with utils.try_with_location(location):


### PR DESCRIPTION
Hoping to help facilitate discussion of https://github.com/google/gin-config/issues/86

This is a relatively simple change which allows a user to parse a config with *with* a scope, essentially just prepending the scope to every statement.  One thing this option breaks is using a macro defined in a scope, for example:

```
X = 1
foo.bar = %X
```

Will fail if this file is parsed with a scope since it would be equivalent to 

```
scope/X = 1
scope/foo.bar = %X
```

Please leave any comments or suggestions