### PR TITLE
Register dynamically imported configurables under their real module

ParseContext._register built the configurable's module name from
ImportStatement.partial_path(), which for an aliased import substitutes
the alias into the path (import gin.testdata.dynamic_registration as dr
produced 'gin.testdata.dr.Class'). The registry selector then didn't
match the real module, so gin.get_bindings()/get_configurable() failed
for modules that were only ever imported under an alias, and the same
configurable could be registered twice under different names across
files. Use module_path() so the registered name always reflects the
real module.

### DIFF
--- a/gin/config.py
+++ b/gin/config.py
@@ -302,7 +302,9 @@ class ParseContext:
     if source is None:  # This happens for Gin "builtins" like `macro`.
       module = root_name
     else:
-      module = '.'.join([source.partial_path(), *inner_names])
+      # Aliased imports must still use the real module path; `partial_path()`
+      # substitutes the alias into the module name.
+      module = '.'.join([source.module_path(), *inner_names])
 
     original = _inverse_lookup(fn_or_cls)
     _make_configurable(

--- a/gin/config_parser.py
+++ b/gin/config_parser.py
@@ -116,6 +116,17 @@ class ImportStatement(typing.NamedTuple):
     else:  # not self.is_from and not self.alias
       return self.module.split('.')[0]
 
+  def module_path(self):
+    """Returns the module path that the bound name refers to.
+
+    A plain `import a.b.c` binds only the top-level name `a`, so the bound name
+    refers to `a`. Aliased and `from` imports bind a name that refers to the
+    full module (e.g. `a.b.c`), since the name is bound to that module.
+    """
+    if self.is_from or self.alias:
+      return self.module
+    return self.module.split('.')[0]
+
 
 class IncludeStatement(typing.NamedTuple):
   filename: str

--- a/tests/config_parser_test.py
+++ b/tests/config_parser_test.py
@@ -367,6 +367,7 @@ class ConfigParserTest(absltest.TestCase):
     self.assertEqual(imports[i].format(), 'import some.module.name')
     self.assertEqual(imports[i].bound_name(), 'some')
     self.assertEqual(imports[i].partial_path(), 'some')
+    self.assertEqual(imports[i].module_path(), 'some')
 
     i += 1
     self.assertEqual(imports[i].module, 'another.module.name')
@@ -375,6 +376,7 @@ class ConfigParserTest(absltest.TestCase):
     self.assertEqual(imports[i].format(), 'import another.module.name')
     self.assertEqual(imports[i].bound_name(), 'another')
     self.assertEqual(imports[i].partial_path(), 'another')
+    self.assertEqual(imports[i].module_path(), 'another')
 
     i += 1
     self.assertEqual(imports[i].module, 'some.module.name')
@@ -383,6 +385,7 @@ class ConfigParserTest(absltest.TestCase):
     self.assertEqual(imports[i].format(), 'import some.module.name as alias')
     self.assertEqual(imports[i].bound_name(), 'alias')
     self.assertEqual(imports[i].partial_path(), 'some.module.alias')
+    self.assertEqual(imports[i].module_path(), 'some.module.name')
 
     i += 1
     self.assertEqual(imports[i].module, 'another.module.name')
@@ -391,6 +394,7 @@ class ConfigParserTest(absltest.TestCase):
     self.assertEqual(imports[i].format(), 'from another.module import name')
     self.assertEqual(imports[i].bound_name(), 'name')
     self.assertEqual(imports[i].partial_path(), 'another.module.name')
+    self.assertEqual(imports[i].module_path(), 'another.module.name')
 
     i += 1
     self.assertEqual(imports[i].module, 'some.module.name')
@@ -400,6 +404,7 @@ class ConfigParserTest(absltest.TestCase):
                      'from some.module import name as alias')
     self.assertEqual(imports[i].bound_name(), 'alias')
     self.assertEqual(imports[i].partial_path(), 'some.module.alias')
+    self.assertEqual(imports[i].module_path(), 'some.module.name')
 
     with self.assertRaises(SyntaxError):
       self._parse_config('import a.0b')

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -22,7 +22,9 @@ import io
 import logging
 import os
 import pickle
+import sys
 import threading
+import types
 
 from absl.testing import absltest
 
@@ -829,6 +831,39 @@ class ConfigTest(absltest.TestCase):
     config.parse_config(config_str)
     bindings = config.get_bindings('gin.testdata.dynamic_registration.Class')
     self.assertEqual(bindings, {'a': 1, 'b': 2})
+
+  def testDynamicRegistrationAliasedImportUsesRealModuleName(self):
+    # Register a synthetic module that no other test imports, so registry state
+    # left behind by earlier tests can't mask a regression here.
+    module_name = 'gin.testdata.dynamic_registration_alias_test'
+    module = types.ModuleType(module_name)
+
+    class Class:
+      def __init__(self, a, b=None):
+        self.a = a
+        self.b = b
+
+    def function():
+      return 2
+
+    module.Class = Class
+    module.function = function
+    sys.modules[module_name] = module
+    try:
+      config_str = """
+        from __gin__ import dynamic_registration
+
+        import gin.testdata.dynamic_registration_alias_test as dr
+
+        dr.Class.a = 1
+        dr.Class.b = @dr.function()
+      """
+      config.parse_config(config_str)
+      bindings = config.get_bindings(
+          'gin.testdata.dynamic_registration_alias_test.Class')
+      self.assertEqual(bindings, {'a': 1, 'b': 2})
+    finally:
+      del sys.modules[module_name]
 
   def testDynamicRegistrationMacro(self):
     config_str = """


### PR DESCRIPTION
## Problem

With `from __gin__ import dynamic_registration`, referencing a
configurable through an aliased import registers it under a fake module
name:

```gin
import gin.testdata.dynamic_registration as dr

dr.Class.a = 1
```

registers the class as `gin.testdata.dr.Class`, because
`ParseContext._register` built the module name with
`ImportStatement.partial_path()`, which splices the alias into the path.
The registry entry therefore doesn't match the module's real name:
`gin.get_configurable('gin.testdata.dynamic_registration.Class')` fails,
and if the same module is imported both normally and under an alias, it
ends up registered twice under two different names.

## Fix

Add `ImportStatement.module_path()`, which returns the module a bound
name actually refers to:

- plain `import a.b.c` binds the top-level name `a`, so it returns `a`;
- aliased and `from` imports bind the imported module itself, so they
  return the full module (e.g. `a.b.c`).

`ParseContext._register` now uses `module_path()` instead of
`partial_path()` when computing a configurable's module, so registered
names always reflect the real module regardless of how the file imported
it. `partial_path()` is unchanged; it is still used where a config
literal's dotted path is constructed.

## Tests

- Parser unit assertions for `module_path()` across all five import
  forms in `testParseImports`.
- A regression test that registers a synthetic module in `sys.modules`
  (one no other test imports, so registry state from earlier tests can't
  mask a regression), binds through an aliased import, and asserts the
  bindings are reachable via the real module path. This test is
  order-independent: it fails on master and passes with the fix.

I verified the existing dynamic-registration import tests
(`testDynamicRegistrationImportAs`, `FromImportAs`) also pass when run
in isolation, which they don't on master.